### PR TITLE
move crds back to helm crds directory

### DIFF
--- a/charts/spicedb-operator/Chart.yaml
+++ b/charts/spicedb-operator/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/spicedb-operator/crds/authzed.com_spicedbclusters.yaml
+++ b/charts/spicedb-operator/crds/authzed.com_spicedbclusters.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -271,4 +270,3 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end }}

--- a/charts/spicedb-operator/values.yaml
+++ b/charts/spicedb-operator/values.yaml
@@ -12,9 +12,6 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-# Install the SpiceDBCluster CRD
-installCRDs: true
-
 # Labels to add to all standard Kubernetes resources, including the operator's deployment and pods
 commonLabels: {}
 


### PR DESCRIPTION
move crds back to helm crds directory to support multi-namespace installs and maintain backwards compatibility