### PR TITLE
Move CRD to templates to preserve upgrade path from chart 2.0.0

### DIFF
--- a/charts/spicedb-operator/Chart.yaml
+++ b/charts/spicedb-operator/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/spicedb-operator/templates/crds/authzed.com_spicedbclusters.yaml
+++ b/charts/spicedb-operator/templates/crds/authzed.com_spicedbclusters.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -283,3 +284,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/spicedb-operator/values.yaml
+++ b/charts/spicedb-operator/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Install the SpiceDBCluster CRD as a template resource.
+# This ensures the CRD is managed by Helm on both install and upgrade.
+installCRDs: true
+
 image:
   repository: ghcr.io/authzed/spicedb-operator
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Hello @croemmich 

Upgrading from chart 2.0.0 to 2.3.0 causes Helm to delete the CRD, because the CRD was a template resource in 2.0.0 but was removed from templates in 2.3.0. Helm treats this as a deleted resource and removes it from the cluster. 

Moving the CRD back to templates/ with an installCRDs toggle ensures it is managed on both install and upgrade.