### PR TITLE
Add update-graph.yaml customization options

### DIFF
--- a/charts/spicedb-operator/Chart.yaml
+++ b/charts/spicedb-operator/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0
+version: 2.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/spicedb-operator/README.md
+++ b/charts/spicedb-operator/README.md
@@ -1,6 +1,6 @@
 # spicedb-operator
 
-![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.23.0](https://img.shields.io/badge/AppVersion-v1.23.0-informational?style=flat-square)
+![Version: 2.6.0](https://img.shields.io/badge/Version-2.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.23.0](https://img.shields.io/badge/AppVersion-v1.23.0-informational?style=flat-square)
 
 A Helm chart to install the SpiceDB Operator
 
@@ -45,5 +45,8 @@ A Helm chart to install the SpiceDB Operator
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| spiceDB.allowedImages | list | `[]` | Allowlisted SpiceDB image repositories (paths without tag). When empty, `allowedImages` is omitted from operator global config. |
+| spiceDB.disableImageValidation | bool | `false` | When true, sets `disableImageValidation` in operator global config. |
+| spiceDB.imageName | string | `"ghcr.io/authzed/spicedb"` | Default SpiceDB container image repository (path without tag). |
 | strategy | object | `{}` |  |
 | tolerations | list | `[]` |  |

--- a/charts/spicedb-operator/templates/configmap-update-graph.yaml
+++ b/charts/spicedb-operator/templates/configmap-update-graph.yaml
@@ -3289,4 +3289,13 @@ data:
         tag: v1.3.0
       - id: v1.2.0
         tag: v1.2.0
-    imageName: ghcr.io/authzed/spicedb
+{{- if .Values.spiceDB.allowedImages }}
+    allowedImages:
+{{- range .Values.spiceDB.allowedImages }}
+      - {{ . | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.spiceDB.disableImageValidation }}
+    disableImageValidation: true
+{{- end }}
+    imageName: {{ .Values.spiceDB.imageName | quote }}

--- a/charts/spicedb-operator/values.yaml
+++ b/charts/spicedb-operator/values.yaml
@@ -93,3 +93,12 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# -- SpiceDB workload image settings merged into the operator global config (`update-graph.yaml`). See [Authzed operator docs](https://authzed.com/docs/spicedb/ops/operator#global-config).
+spiceDB:
+  # -- Default SpiceDB container image repository (path without tag). Must match your mirror if using a private registry.
+  imageName: ghcr.io/authzed/spicedb
+  # -- Allowlisted SpiceDB image repositories (each path without tag). When empty, the `allowedImages` key is omitted so behavior matches older chart releases.
+  allowedImages: []
+  # -- When true, sets `disableImageValidation: true` in operator global config (suppresses warnings for images outside the allowlist).
+  disableImageValidation: false


### PR DESCRIPTION
We also want to start using this chart for SpiceDB and want the operator to use our internal image pull-through-cache.

For this I added a feature to customize the `update-graph.yaml` accordingly.

I'd appreciate a review.

Thanks!